### PR TITLE
Fix caregiver document upload sending only changed files on edit.

### DIFF
--- a/src/View/employee-view/components/CareGiverFileUploader.tsx
+++ b/src/View/employee-view/components/CareGiverFileUploader.tsx
@@ -84,13 +84,18 @@ const CareGiverFileUploader = ({
   useEffect(() => {
     setUploadFiles(documents.map((doc) => doc.file).filter(Boolean) as File[]);
     setCareGiverDocuments(
-      documents.map((doc) => ({
-        careGiverID: careGiverSlice.selectedCareGiver?.careGiverID || "",
-        documentTypeID: doc.documentTypeID,
-        expDate: doc.expirationDate || "",
-        status: "Pending",
-        document: doc.uploadedDocument || "",
-      }))
+      documents.map((doc) => {
+        const existing = careGiverSlice.selectedCareGiver?.careGiverDocuments?.find(
+          (d) => d.documentTypeID === doc.documentTypeID
+        );
+        return {
+          careGiverID: careGiverSlice.selectedCareGiver?.careGiverID || "",
+          documentTypeID: doc.documentTypeID,
+          expDate: doc.expirationDate || existing?.expDate || "",
+          status: existing?.status || "Pending",
+          document: doc.uploadedDocument || "",
+        };
+      })
     );
   }, [documents]);
 

--- a/src/View/employee-view/modal/StaffModal.tsx
+++ b/src/View/employee-view/modal/StaffModal.tsx
@@ -229,10 +229,14 @@ const StaffModal = ({
         careGiverStatus?.selectedCareGiver != null &&
         checkIsRequiredFilesUploaded()
       ) {
+        const documentsForUpdate = careGiverDocuments?.filter((doc) => {
+          if (doc?.document == null || doc?.document === "") {
+            return false;
+          }
+          return uploadFiles.some((file) => file.name === doc.document);
+        });
         const careGiverPayload: CareGiver = {
-          careGiverDocuments: careGiverDocuments?.filter(
-            (doc) => doc?.document != "" && doc?.document != null
-          ),
+          careGiverDocuments: documentsForUpdate,
           careGiverPayments: careGiverPayments,
           employee: { ...employeeBasicInformation, status: employeeState },
           careGiverID: careGiverStatus.selectedCareGiver.careGiverID,


### PR DESCRIPTION
Preserve server status per document type and limit update payload to newly uploaded files.